### PR TITLE
Fixes for HostConfig and LxcConf. Added DockerClient.logContainerStream method.

### DIFF
--- a/src/main/java/com/kpelykh/docker/client/DockerClient.java
+++ b/src/main/java/com/kpelykh/docker/client/DockerClient.java
@@ -5,6 +5,7 @@ import com.kpelykh.docker.client.model.*;
 import com.kpelykh.docker.client.utils.CompressArchiveUtil;
 import com.kpelykh.docker.client.utils.JsonClientFilter;
 import com.sun.jersey.api.client.*;
+import com.sun.jersey.api.client.WebResource.Builder;
 import com.sun.jersey.api.client.config.ClientConfig;
 import com.sun.jersey.api.client.config.DefaultClientConfig;
 import com.sun.jersey.api.json.JSONConfiguration;
@@ -343,7 +344,12 @@ public class DockerClient
 
         try {
             LOGGER.trace("POST: " + webResource.toString());
-            webResource.accept(MediaType.TEXT_PLAIN).post(hostConfig);
+            Builder builder = webResource.accept(MediaType.TEXT_PLAIN);
+            if (hostConfig != null) {
+                builder.type(MediaType.APPLICATION_JSON).post(hostConfig);
+            } else {
+                builder.post((HostConfig) null);
+            }
         } catch (UniformInterfaceException exception) {
             if (exception.getResponse().getStatus() == 404) {
                 throw new DockerException(String.format("No such container %s", containerId));

--- a/src/main/java/com/kpelykh/docker/client/DockerClient.java
+++ b/src/main/java/com/kpelykh/docker/client/DockerClient.java
@@ -443,11 +443,21 @@ public class DockerClient
 
 
     public ClientResponse logContainer(String containerId) throws DockerException {
+        return logContainer(containerId, false);
+    }
+
+    public ClientResponse logContainerStream(String containerId) throws DockerException {
+        return logContainer(containerId, true);
+    }
+
+    private ClientResponse logContainer(String containerId, boolean stream) throws DockerException {
         MultivaluedMap<String,String> params = new MultivaluedMapImpl();
         params.add("logs", "1");
         params.add("stdout", "1");
         params.add("stderr", "1");
-        //params.add("stream", "1"); this parameter keeps stream open indindefinitely
+        if (stream) {
+            params.add("stream", "1"); // this parameter keeps stream open indefinitely
+        }
 
         WebResource webResource = client.resource(restEndpointUrl + String.format("/containers/%s/attach", containerId))
                 .queryParams(params);

--- a/src/main/java/com/kpelykh/docker/client/model/HostConfig.java
+++ b/src/main/java/com/kpelykh/docker/client/model/HostConfig.java
@@ -16,7 +16,7 @@ public class HostConfig {
     public String containerIDFile;
 
     @JsonProperty("LxcConf")
-    public String[] lxcConf = new String[]{};
+    public LxcConf[] lxcConf;
 
     public HostConfig(String[] binds) {
         this.binds = binds;
@@ -38,11 +38,36 @@ public class HostConfig {
         this.containerIDFile = containerIDFile;
     }
 
-    public String[] getLxcConf() {
+    public LxcConf[] getLxcConf() {
         return lxcConf;
     }
 
-    public void setLxcConf(String[] lxcConf) {
+    public void setLxcConf(LxcConf[] lxcConf) {
         this.lxcConf = lxcConf;
+    }
+
+    public class LxcConf {
+        @JsonProperty("Key")
+        public String key;
+
+        @JsonProperty("Value")
+        public String value;
+
+        public String getKey() {
+            return key;
+        }
+
+        public void setKey(String key) {
+            this.key = key;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+
     }
 }


### PR DESCRIPTION
This pull request has two changes.
1. Fixes for HostConfig and LxcConf. I tested these in my own project.
2. Added DockerClient.logContainerStream, which is the same as logContainer, but keeps the stream open indefinitely.
