### PR TITLE
Adding <space> after ADD command to not to confuse with other non-docker commands

### DIFF
--- a/src/main/java/com/kpelykh/docker/client/DockerClient.java
+++ b/src/main/java/com/kpelykh/docker/client/DockerClient.java
@@ -643,7 +643,7 @@ public class DockerClient
             FileUtils.copyFileToDirectory(dockerFile, tmpDockerContextFolder);
 
             for (String cmd : dockerFileContent) {
-                if (StringUtils.startsWithIgnoreCase(cmd.trim(), "ADD")) {
+                if (StringUtils.startsWithIgnoreCase(cmd.trim(), "ADD ")) {
                     String addArgs[] = StringUtils.split(cmd, " \t");
                     if (addArgs.length != 3) {
                         throw new DockerException(String.format("Wrong format on line [%s]", cmd));


### PR DESCRIPTION
Adding space after ADD to avoid issues with non-docker commands like add-apt-repository.
Otherwise getting exceptions like this - com.kpelykh.docker.client.DockerException: Wrong format on line [ add-apt-repository 'deb http://mirror.jmu.edu/pub/mariadb/repo/5.5/ubuntu precise main' && ]

Cheers!!!
