### PR TITLE
Added new fields to comply with Docker 0.8.1 API changes

### DIFF
--- a/src/main/java/com/kpelykh/docker/client/model/ContainerConfig.java
+++ b/src/main/java/com/kpelykh/docker/client/model/ContainerConfig.java
@@ -37,6 +37,7 @@ public class ContainerConfig {
     @JsonProperty("Domainname")   private String domainName = "";
     // FIXME Is this the right type? -BJE
     @JsonProperty("ExposedPorts")   private Map<String, ?> exposedPorts;
+    @JsonProperty("OnBuild")          private String[]  onBuild;
 
     public Map<String, ?> getExposedPorts() {
         return exposedPorts;
@@ -240,6 +241,14 @@ public class ContainerConfig {
     public ContainerConfig setEntrypoint(String[] entrypoint) {
         this.entrypoint = entrypoint;
         return this;
+    }
+
+    public String[] getOnBuild() {
+	return onBuild;
+    }
+
+    public void setOnBuild(String[] onBuild) {
+	this.onBuild=onBuild;
     }
 
     @Override

--- a/src/main/java/com/kpelykh/docker/client/model/Info.java
+++ b/src/main/java/com/kpelykh/docker/client/model/Info.java
@@ -63,6 +63,9 @@ public class Info {
     @JsonProperty("SwapLimit")
     private int swapLimit;
 
+    @JsonProperty("ExecutionDriver")
+    private String executionDriver;
+
     public boolean isDebug() {
         return debug;
     }
@@ -189,6 +192,13 @@ public class Info {
 
     public void setSwapLimit(int swapLimit) {
         this.swapLimit = swapLimit;
+    }
+    public String getExecutionDriver() {
+        return executionDriver;
+    }
+
+    public void setExecutionDriver(String executionDriver) {
+        this.executionDriver=executionDriver;
     }
 
     @Override


### PR DESCRIPTION
Added the fields introduced in Docker 0.8.1(not sure if this is preferable to just marking them as ingorable)  There are no errors when I run the tests against 0.8.1 and I have been able to incorporate this into my own project running against 0.8.1 without any issues.
