### PR TITLE
Throw a NotFoundException when 404's are received 

### DIFF
--- a/src/main/java/com/kpelykh/docker/client/NotFoundException.java
+++ b/src/main/java/com/kpelykh/docker/client/NotFoundException.java
@@ -1,0 +1,20 @@
+package com.kpelykh.docker.client;
+
+/**
+ * Indicates that the given entity does not exist.
+ *
+ * @author Ryan Campbell ryan.campbell@gmail.com
+ */
+public class NotFoundException extends DockerException {
+    public NotFoundException() {
+
+    }
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+
+    public NotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
So that these can be handled more easily.

This change is backwards compatible. Looking for things that aren't there is a common use-case, so it should be easy to do.
