### PR TITLE
Removed "charset:UTF-8" from Content-Type.

### DIFF
--- a/src/main/java/com/kpelykh/docker/client/utils/JsonClientFilter.java
+++ b/src/main/java/com/kpelykh/docker/client/utils/JsonClientFilter.java
@@ -5,10 +5,6 @@ import com.sun.jersey.api.client.ClientRequest;
 import com.sun.jersey.api.client.ClientResponse;
 import com.sun.jersey.api.client.filter.ClientFilter;
 
-import javax.ws.rs.core.MediaType;
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  *
  * @author Konstantin Pelykh (kpelykh@gmail.com)
@@ -17,12 +13,6 @@ import java.util.Map;
 public class JsonClientFilter extends ClientFilter {
 
     public ClientResponse handle(ClientRequest cr) {
-        MediaType contentType = (MediaType) cr.getHeaders().getFirst("Content-Type");
-        if (contentType != null && !contentType.getParameters().containsKey("charset")) {
-            Map<String,String> contentParams = new HashMap<String, String>();
-            contentParams.put("charset", "UTF-8");
-            cr.getHeaders().putSingle("Content-Type", new MediaType(contentType.getType(), contentType.getSubtype(), contentParams));
-        }
         // Call the next filter
         ClientResponse resp = getNext().handle(cr);
         String respContentType = resp.getHeaders().getFirst("Content-Type");


### PR DESCRIPTION
The Docker API does not specify including charset:utf-8 in the Content-Type.

In fact, some API methods will not work correctly if the charset is specified, such as "copy" as mentioned in https://github.com/kpelykh/docker-java/issues/10
