### PR TITLE
redirect JUL logging to SLF4J so we can avoid logging binary to the cons...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.github.jnr</groupId>
+                <artifactId>jffi</artifactId>
+                <version>1.2.7</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.jnr</groupId>
+                <artifactId>jffi</artifactId>
+                <classifier>native</classifier>
+                <version>1.2.7</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,9 @@
     </licenses>
 
     <scm>
-        <connection>scm:git:git@github.com:kpelykh/docker-java.git</connection>
-        <url>git@github.com:kpelykh/docker-java.git</url>
-        <developerConnection>scm:git:git@github.com:kpelykh/docker-java.git</developerConnection>
+        <connection>scm:git:git@github.com:alexec/docker-java.git</connection>
+        <url>git@github.com:alexec/docker-java.git</url>
+        <developerConnection>scm:git:git@github.com:alexec/docker-java.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
...ole when using ADD in Dockerfile

When you have a Dockerfile with a ADD that is a binary file, logging to the Terminal (on OS-X) crashes the terminal. 
